### PR TITLE
Fix for the "Cannot clear leftmost column bug" issue

### DIFF
--- a/GitHub-Tetris-Chromium/tetris.js
+++ b/GitHub-Tetris-Chromium/tetris.js
@@ -118,7 +118,7 @@ const clearTetromino = () => {
 
 // Function to check and clear full columns, then move the stack left
 const clearFullColumns = () => {
-  for (let x = -1; x < 52; x++) { // Cause why not?
+  for (let x = -1; x < 52; x++) { // Cause why not? This is the easiest adjustment of scanning to the left change there is... - SolarPH
     // Check if the column is full (all cells in the column are filled)
     const isFullColumn = contributionArray.every(row => row[x] && row[x].getAttribute('data-level') !== '0');
     

--- a/GitHub-Tetris-Chromium/tetris.js
+++ b/GitHub-Tetris-Chromium/tetris.js
@@ -118,7 +118,7 @@ const clearTetromino = () => {
 
 // Function to check and clear full columns, then move the stack left
 const clearFullColumns = () => {
-  for (let x = 0; x < 52; x++) {
+  for (let x = -1; x < 52; x++) { // Cause why not?
     // Check if the column is full (all cells in the column are filled)
     const isFullColumn = contributionArray.every(row => row[x] && row[x].getAttribute('data-level') !== '0');
     

--- a/tetris.js
+++ b/tetris.js
@@ -118,7 +118,7 @@ const clearTetromino = () => {
 
 // Function to check and clear full columns, then move the stack left
 const clearFullColumns = () => {
-  for (let x = 0; x < 52; x++) {
+  for (let x = -1; x < 52; x++) { // Cause why not? This is the easiest adjustment of scanning to the left change there is... - SolarPH
     // Check if the column is full (all cells in the column are filled)
     const isFullColumn = contributionArray.every(row => row[x] && row[x].getAttribute('data-level') !== '0');
     


### PR DESCRIPTION
Hello!

I was the one on the facebook page that noticed that column that cannot be cleared.

I adjusted the value of your for loop since all "x" variables don't have adjustments on them, so I thought changing it from 0 to -1 might fix it.

Upon testing on edge, it does work, which seems to be an easy fix, and probably a weird indexing issue.